### PR TITLE
Updates for redirecting to a FB Canvas App

### DIFF
--- a/application/config/facebook.php
+++ b/application/config/facebook.php
@@ -4,3 +4,4 @@
 	$config['facebook_api_secret'] 		= '';
 	$config['facebook_default_scope']	= ''; // E.G 'read_stream,birthday,users_events,rsvp_event'
 	$config['facebook_api_url'] 		= 'https://graph.facebook.com/'; // Just in case it changes.
+	$config['facebook_canvas_url'] 	= 'https://apps.facebook.com/YOUR_APP_NAME'; // Just in case it changes.

--- a/application/libraries/facebook.php
+++ b/application/libraries/facebook.php
@@ -354,6 +354,11 @@
 		
 		public function login_url($scope = NULL)
 		{
+			if( !empty($this->_canvas_url) )
+			{
+				$this->_set('callback', $this->_canvas_url);
+			}
+			
 			$url = "http://www.facebook.com/dialog/oauth?client_id=".$this->_api_key.'&redirect_uri='.urlencode($this->_get('callback'));
 			
 			if ( empty($scope) )

--- a/application/libraries/facebook.php
+++ b/application/libraries/facebook.php
@@ -325,6 +325,7 @@
 			
 			$this->_api_key 	= $this->_obj->config->item('facebook_app_id');
 			$this->_api_secret 	= $this->_obj->config->item('facebook_api_secret');
+			$this->_canvas_url 	= $this->_obj->config->item('facebook_canvas_url');
 			
 			$this->_token_url 	= $this->_obj->config->item('facebook_api_url').$this->_token_url;
 			$this->_user_url 	= $this->_obj->config->item('facebook_api_url').$this->_user_url;

--- a/application/libraries/facebook.php
+++ b/application/libraries/facebook.php
@@ -362,10 +362,6 @@
 			else
 			{
 				$this->_set('scope', $scope);
-			}
-			
-			if ( !empty($scope) )
-			{
 				$url .= '&scope='.$scope;
 			}
 			

--- a/application/libraries/facebook.php
+++ b/application/libraries/facebook.php
@@ -20,6 +20,7 @@
 			$this->_api_url 	= $this->_obj->config->item('facebook_api_url');
 			$this->_api_key 	= $this->_obj->config->item('facebook_app_id');
 			$this->_api_secret 	= $this->_obj->config->item('facebook_api_secret');
+			$this->_canvas_url 	= $this->_obj->config->item('facebook_canvas_url');
 			
 			$this->session = new facebookSession();
 			$this->connection = new facebookConnection();


### PR DESCRIPTION
As my last pull request stated:

I have made some modifications as needed to send my users back to Facebook to my canvas app in order to use the app in an iFrame.

Please review the changes, test, and help me make sure I'm on the right track. Hopefully this will be useful to others who are trying to run CI apps in the Facebook App canvas mode.

Thanks!
Sean
